### PR TITLE
Update queue.js error message

### DIFF
--- a/node/queue.js
+++ b/node/queue.js
@@ -51,7 +51,7 @@ module.exports = function (RED) {
                 send({ _queue: queue })
                 this.status({ fill: 'grey', shape: 'dot', text: 'Queue is empty' })
             } else {
-                this.error('Invalid operation. Use "enqueue", "dequeue", "preview", or "clear".', msg)
+                this.error('Invalid operation. Use "enqueue", "dequeue", "get", or "clear".', msg)
             }
 
             done()


### PR DESCRIPTION
Changed "preview" to "get" so that the error message reflects the proper commands to use the node.